### PR TITLE
review commit for payment info fix

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,11 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+
+[dev-packages]
+
+[requires]
+python_version = "3.9"

--- a/bangazonapi/views/paymenttype.py
+++ b/bangazonapi/views/paymenttype.py
@@ -34,8 +34,8 @@ class Payments(ViewSet):
         new_payment = Payment()
         new_payment.merchant_name = request.data["merchant_name"]
         new_payment.account_number = request.data["account_number"]
-        new_payment.expiration_date = request.data["create_date"]
-        new_payment.create_date = request.data["expiration_date"]
+        new_payment.expiration_date = request.data["expiration_date"]
+        new_payment.create_date = request.data["create_date"]
         customer = Customer.objects.get(user=request.auth.user)
         new_payment.customer = customer
         new_payment.save()


### PR DESCRIPTION
Customers were complaining that the expiration date on their payment types were incorrect.

## Changes

- In `paymenttype.py` the `new_payment.expiration_date = request.data` changed from `["create_date"]` to `["expiration_date"]`
- In `paymenttype.py` the `new_payment.create_date = request.data` changed from `['expiration_date"]` to `["create_date"]`

## Requests / Responses


**Request**

POST `/paymenttypes` Creates a new payment type http://localhost:8000/paymenttypes

```json
{
    "merchant_name": "Amex",
    "account_number": "000000000000",
    "expiration_date": "2023-12-12",
    "create_date": "2020-12-12"
}
```

**Response**

HTTP/1.1 201 OK

```json
{
    "id": 5,
    "url": "http://localhost:8000/paymenttypes/5",
    "merchant_name": "Amex",
    "account_number": "000000000000",
    "expiration_date": "2023-12-12",
    "create_date": "2020-12-12"
}
```

## Testing

Open `Products folder` in Postman. The Products folder will be found on the left nav bar.
Click on POST Create a Payment Type to auto-populate POST command.
Check BODY for JSON data to post. Test data may auto-populate.  
Click SEND to complete the POST Request.
Response should show the payment type info with the correct `expiration_date` listed,


## Related Issues

- Fixes #28
