### PR TITLE
Review bugfix for Paymenttype Return Issue | API 

### DIFF
--- a/bangazonapi/views/paymenttype.py
+++ b/bangazonapi/views/paymenttype.py
@@ -79,13 +79,17 @@ class Payments(ViewSet):
 
     def list(self, request):
         """Handle GET requests to payment type resource"""
-        payment_types = Payment.objects.all()
+        user = request.user
+        if user.is_authenticated:
+            payment_types = Payment.objects.filter(customer__user=user)
+        else:
+            payment_types = Payment.objects.none()
 
-        customer_id = self.request.query_params.get('customer', None)
+        """ customer_id = self.request.query_params.get('customer', None)
 
         if customer_id is not None:
             payment_types = payment_types.filter(customer__id=customer_id)
-
+ """
         serializer = PaymentSerializer(
             payment_types, many=True, context={'request': request})
         return Response(serializer.data)


### PR DESCRIPTION
When the client performs a GET request to the `/paymenttypes` resources, only the payment types added by the authenticated user should be returned. Originally, all payment types in the system are being returned..

## Changes

- Updated the code for 'List' in the `/paymenttypes` view to check for user authentication
- Updated the code for 'List' to `.filter` method the payment type for the authenticated user only 

## Requests / Responses

If this PR contains code that defines a new request/response, or changes an existing one, please put the JSON representations here.

**Request**

GET `/paymenttype` Creates a list of payment types for an authenticated user http://localhost:8000/paymenttypes

```json
{
        "model": "bangazonapi.payment",
        "pk": 3,
        "fields": {
            "merchant_name": "Visa",
            "account_number": "fj0398fjw0g89434",
            "customer_id": "7",
            "expiration_date": "2020-03-01",
            "create_date": "2019-03-11"
        }
    }
```

**Response**

HTTP/1.1 200 OK

```json
[
    {
        "id": 3,
        "url": "http://localhost:8000/paymenttypes/3",
        "merchant_name": "Visa",
        "account_number": "fj0398fjw0g89434",
        "expiration_date": "2020-03-01",
        "create_date": "2019-03-11"
    }
]
```

## Testing

In Postman:
- [ ] Expand the Products folder (left nav), then click the 'GET all payment types', doing so should auto-populate the GET fetch. 
- [ ] In `Headers`, create a `key` "Authorization" using `token` "9ba45f09651c5b0c404f37a2d2572c026c14669c"
- [ ] Click SEND
- [ ] You should see payment type(s) for all the user assigned to that token

- [ ] Additional token if you want to do further testing (9ba45f09651c5b0c404f37a2d2572c026c146694 / should return Visa last3: 439 exp:1/1/20)


## Related Issues

- Fixes #27