### PR TITLE
Bugfix/min products sold #30

### DIFF
--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -1,4 +1,5 @@
 """View module for handling requests about products"""
+
 from rest_framework.decorators import action
 from bangazonapi.models.recommendation import Recommendation
 import base64
@@ -15,16 +16,28 @@ from rest_framework.parsers import MultiPartParser, FormParser
 
 class ProductSerializer(serializers.ModelSerializer):
     """JSON serializer for products"""
+
     class Meta:
         model = Product
-        fields = ('id', 'name', 'price', 'number_sold', 'description',
-                  'quantity', 'created_date', 'location', 'image_path',
-                  'average_rating', 'can_be_rated', )
+        fields = (
+            "id",
+            "name",
+            "price",
+            "number_sold",
+            "description",
+            "quantity",
+            "created_date",
+            "location",
+            "image_path",
+            "average_rating",
+            "can_be_rated",
+        )
         depth = 1
 
 
 class Products(ViewSet):
     """Request handlers for Products in the Bangazon Platform"""
+
     permission_classes = (IsAuthenticatedOrReadOnly,)
 
     def create(self, request):
@@ -98,16 +111,18 @@ class Products(ViewSet):
         new_product.category = product_category
 
         if "image_path" in request.data:
-            format, imgstr = request.data["image_path"].split(';base64,')
-            ext = format.split('/')[-1]
-            data = ContentFile(base64.b64decode(imgstr), name=f'{new_product.id}-{request.data["name"]}.{ext}')
+            format, imgstr = request.data["image_path"].split(";base64,")
+            ext = format.split("/")[-1]
+            data = ContentFile(
+                base64.b64decode(imgstr),
+                name=f'{new_product.id}-{request.data["name"]}.{ext}',
+            )
 
             new_product.image_path = data
 
         new_product.save()
 
-        serializer = ProductSerializer(
-            new_product, context={'request': request})
+        serializer = ProductSerializer(new_product, context={"request": request})
 
         return Response(serializer.data, status=status.HTTP_201_CREATED)
 
@@ -152,7 +167,7 @@ class Products(ViewSet):
         """
         try:
             product = Product.objects.get(pk=pk)
-            serializer = ProductSerializer(product, context={'request': request})
+            serializer = ProductSerializer(product, context={"request": request})
             return Response(serializer.data)
         except Exception as ex:
             return HttpResponseServerError(ex)
@@ -209,10 +224,12 @@ class Products(ViewSet):
             return Response({}, status=status.HTTP_204_NO_CONTENT)
 
         except Product.DoesNotExist as ex:
-            return Response({'message': ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
+            return Response({"message": ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
 
         except Exception as ex:
-            return Response({'message': ex.args[0]}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(
+                {"message": ex.args[0]}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
 
     def list(self, request):
         """
@@ -245,18 +262,18 @@ class Products(ViewSet):
         products = Product.objects.all()
 
         # Support filtering by category and/or quantity
-        category = self.request.query_params.get('category', None)
-        quantity = self.request.query_params.get('quantity', None)
-        order = self.request.query_params.get('order_by', None)
-        direction = self.request.query_params.get('direction', None)
-        number_sold = self.request.query_params.get('number_sold', None)
+        category = self.request.query_params.get("category", None)
+        quantity = self.request.query_params.get("quantity", None)
+        order = self.request.query_params.get("order_by", None)
+        direction = self.request.query_params.get("direction", None)
+        number_sold = self.request.query_params.get("number_sold", None)
 
         if order is not None:
             order_filter = order
 
             if direction is not None:
                 if direction == "desc":
-                    order_filter = f'-{order}'
+                    order_filter = f"-{order}"
 
             products = products.order_by(order_filter)
 
@@ -264,21 +281,23 @@ class Products(ViewSet):
             products = products.filter(category__id=category)
 
         if quantity is not None:
-            products = products.order_by("-created_date")[:int(quantity)]
+            products = products.order_by("-created_date")[: int(quantity)]
 
         if number_sold is not None:
+
             def sold_filter(product):
-                if product.number_sold <= int(number_sold):
+                if product.number_sold >= int(number_sold):
                     return True
                 return False
 
             products = filter(sold_filter, products)
 
         serializer = ProductSerializer(
-            products, many=True, context={'request': request})
+            products, many=True, context={"request": request}
+        )
         return Response(serializer.data)
 
-    @action(methods=['post'], detail=True)
+    @action(methods=["post"], detail=True)
     def recommend(self, request, pk=None):
         """Recommend products to other users"""
 


### PR DESCRIPTION
Clients can now request a list of products that have sold at least the specified number of items using the following URL scheme. http://localhost:8000/products?number_sold=20

## Changes

- Changed the operator in the sold_filter function to ">" instead of "<". This changes the logic to return products that have sold more than the minimum amount specified in the request. 

## Requests / Responses


**Request**

GET `http://localhost:8000/products?number_sold=1`

**Response**

HTTP/1.1 200 OK

```json
[
    {
        "id": 45,
        "name": "Optima",
        "price": 1655.15,
        "number_sold": 1,
        "description": "2008 Kia",
        "quantity": 3,
        "created_date": "2019-05-21",
        "location": "Toronto",
        "image_path": "http://localhost:8000/media/products/vehicle.png",
        "average_rating": 0
    },
    {
        "id": 50,
        "name": "Golf",
        "price": 653.59,
        "number_sold": 2,
        "description": "1994 Volkswagen",
        "quantity": 4,
        "created_date": "2019-07-10",
        "location": "Berlin",
        "image_path": "http://localhost:8000/media/products/vehicle.png",
        "average_rating": 3.25
    }
]
```

## Testing

Description of how to test code...

- [ ] Submit a GET request in Postman with the url http://localhost:8000/products?number_sold=1
- [ ] Check to see if the response is like above and that you received a 200 OK message.
- [ ] If the response shows only the two items and not the entire product list, the test is successful.


## Related Issues

- Fixes #30