### PR TITLE
closed order bug fixed

### DIFF
--- a/bangazonapi/views/cart.py
+++ b/bangazonapi/views/cart.py
@@ -33,7 +33,7 @@ class Cart(ViewSet):
             open_order.save()
 
         line_item = OrderProduct()
-        line_item.product = Product.objects.get(pk=request.data["product_id"])
+        line_item.product = Product.objects.get(pk=request.data["id"])
         line_item.order = open_order
         line_item.save()
 

--- a/bangazonapi/views/order.py
+++ b/bangazonapi/views/order.py
@@ -104,7 +104,7 @@ class Orders(ViewSet):
         """
         customer = Customer.objects.get(user=request.auth.user)
         order = Order.objects.get(pk=pk, customer=customer)
-        order.payment_type = request.data["payment_type"]
+        order.payment_type = Payment.objects.get(pk=request.data["payment_type"])
         order.save()
 
         return Response({}, status=status.HTTP_204_NO_CONTENT)

--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -242,7 +242,7 @@ class Profile(ViewSet):
             """
 
             try:
-                open_order = Order.objects.get(customer=current_user)
+                open_order = Order.objects.get(customer=current_user, payment_type__isnull=True)
                 print(open_order)
             except Order.DoesNotExist as ex:
                 open_order = Order()
@@ -251,7 +251,7 @@ class Profile(ViewSet):
                 open_order.save()
 
             line_item = OrderProduct()
-            line_item.product = Product.objects.get(pk=request.data["product_id"])
+            line_item.product = Product.objects.get(pk=request.data["id"])
             line_item.order = open_order
             line_item.save()
 


### PR DESCRIPTION
Fixed issue with products being added to an order that is closed

## Changes

- profile.py - Payment type is null in line 245
- profile.py  - Request data changed to id on line 254
- views/order.py - Correct Payment instance syntax line 107

## Requests / Responses

**Request**

Finish the order by sending a PUT request to the order's URL

```json
{
    "payment_type" : 3
}
```

Add a product to the cart by sending a POST request to http://localhost:8000/profile/cart

```json
{
    "id": 111
}
```

**Response**

HTTP/1.1 200 OK

## Testing

Description of how to test code...

- Open Postman and make sure that an authorized user token is in the Headers section (best example from user "steve")
-  Select PUT and paste the following URL "http://localhost:8000/orders/10"
- Paste - Paste { "payment_type": 3 } in the Body and make sure it is JSON and press Send, this should update the payment method for the order with id of 10
- Select POST and paste the following URL "http://localhost:8000/profile/cart"
- Paste { "id": 111 } in the Body and make sure it is JSON and press Send
- Perform GET "http://localhost:8000/orders"
- Check to see a unique id has been made for a new order with the "payment_type: null"

## Related Issues

- Fixes #33