### PR TITLE
BUGFIX - add new payment

### DIFF
--- a/bangazonapi/models/payment.py
+++ b/bangazonapi/models/payment.py
@@ -10,4 +10,4 @@ class Payment(SafeDeleteModel):
     account_number = models.CharField(max_length=25)
     customer = models.ForeignKey(Customer, on_delete=models.DO_NOTHING, related_name="payment_types")
     expiration_date = models.DateField(default="0000-00-00",)
-    create_date = models.DateField(default="0000-00-00",)
+    create_date = models.DateField(auto_now_add=True,)

--- a/bangazonapi/views/paymenttype.py
+++ b/bangazonapi/views/paymenttype.py
@@ -35,7 +35,6 @@ class Payments(ViewSet):
         new_payment.merchant_name = request.data["merchant_name"]
         new_payment.account_number = request.data["account_number"]
         new_payment.expiration_date = request.data["expiration_date"]
-        new_payment.create_date = request.data["create_date"]
         customer = Customer.objects.get(user=request.auth.user)
         new_payment.customer = customer
         new_payment.save()


### PR DESCRIPTION
The purpose of this pull request is to address an a bug in the API that prevents the client from successfully creating a new payment method in the database

## Changes
• in the Payment model, the create_date property was modified to auto add a date based on creation
• in the Payments viewset create() method, the create_date property was removed, as it is no longer neccessary

## Requests / Responses

If this PR contains code that defines a new request/response, or changes an existing one, please put the JSON representations here.

**Request**

POST `/paymenttypes` Creates a new paymenttype

```json
{
    "merchant_name": "Bmex",
    "account_number": "222222222",
    "expiration_date": "2030-12-12"
}
```

**Response**

HTTP/1.1 201 Created

```json
{
    "id": 8,
    "url": "http://localhost:8000/paymenttypes/8",
    "merchant_name": "Bmex",
    "account_number": "222222222",
    "expiration_date": "2030-12-12",
    "create_date": "2024-03-29"
}
```

## Testing
• Run the API debugger and open postman
• click the "Create a payment type" file in the Products folder
• confirm that a window with a POST method to http://localhost:8000/paymenttypes is opened
• ensure that you have a working user Token in the the authorization header
• replace the existing json request body with the request example above
• Now run the request and you should get response 201 created and a body matching the response above (possibly with different created date depending on when you test this)

