### PR TITLE
Review: Fix for removing an item cart

### DIFF
--- a/bangazonapi/views/lineitem.py
+++ b/bangazonapi/views/lineitem.py
@@ -78,6 +78,8 @@ class LineItems(ViewSet):
             customer = Customer.objects.get(user=request.auth.user)
             order_product = OrderProduct.objects.get(pk=pk, order__customer=customer)
 
+            order_product.delete()
+            
             return Response({}, status=status.HTTP_204_NO_CONTENT)
 
         except OrderProduct.DoesNotExist as ex:


### PR DESCRIPTION
Customers are complaining that they can't remove an item from the cart after it has been added. This ticket satisfies the server side of this request. 

When the client performs a DELETE request to the /lineitems/n resource, it should remove the specified item from the user's cart.

## Changes

- Added missing step: `order_product.delete()` to perform item deletion to **Destroy** in `lineitem.py`


## Requests / Responses

If this PR contains code that defines a new request/response, or changes an existing one, please put the JSON representations here.

**Request**

DELETE `/lineitems/n` Deletes item on an order 

```json
{
   "id": 8,
    "url": "http://localhost:8000/orders/8",
    "created_date": "2019-03-14",
    "payment_type": null,
    "customer": "http://localhost:8000/customers/5",
    "lineitems": [
        {
            **"id": 3,**
            "product": {
                "id": 21,
                "name": "Optima",
                "price": 1655.15,
                "number_sold": 0,
                "description": "2008 Kia",
                "quantity": 3,
                "created_date": "2019-05-21",
                "location": "New York",
                "image_path": "http://localhost:8000/media/products/vehicle.png",
                "average_rating": 0
            }
        }
    ],
    "size": 1
}
```

**Response**

HTTP/1.1 204_NO_CONTENT

```json
{ }
```

## Testing

Description of how to test code...
In Postman:
- [ ] GET orders for authenticated user. `http://localhost:8000/profile/cart`. You can use token 9ba45f09651c5b0c404f37a2d2572c026c146694
- [ ] Then, change request to DELETE and the http://localhost:8000/lineitems/n (n= the item id which should be "3") 


## Related Issues

- Fixes #29