### PR TITLE
FIlter products by location

### DIFF
--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -283,6 +283,7 @@ class Products(ViewSet):
         order = self.request.query_params.get("order_by", None)
         direction = self.request.query_params.get("direction", None)
         number_sold = self.request.query_params.get("number_sold", None)
+        location = self.request.query_params.get("location", None)
 
         if order is not None:
             order_filter = order
@@ -307,6 +308,9 @@ class Products(ViewSet):
                 return False
 
             products = filter(sold_filter, products)
+        
+        if location is not None:
+            products = products.filter(location=location)  # Filter by location
 
         serializer = ProductSerializer(
             products, many=True, context={"request": request}


### PR DESCRIPTION
Description of PR that completes issue here...

## Changes

- Called the location property in the list and added an if statement to filter by location

## Requests / Responses

If this PR contains code that defines a new request/response, or changes an existing one, please put the JSON representations here.

**Request**

GET `/products?location=New+York` Filters by the location of New York


**Response**

HTTP/1.1 200 OK

```json
[
    {
        "id": 11,
        "name": "Optima",
        "price": 1655.15,
        "number_sold": 0,
        "description": "2008 Kia",
        "quantity": 3,
        "created_date": "2019-05-21",
        "location": "New York",
        "image_path": "http://localhost:8000/media/products/vehicle.png",
        "average_rating": 0
    }, 

etc....
```

## Testing

Description of how to test code...

- [ ] Switch to working branch
- [ ] Open Postman and perform GET request above
- [ ] The response above should be the first to come up, the rest that have the location of New York will follow
- [ ] OPTIONAL: The filter by location button works on front-end if testing is desired


## Related Issues

- Fixes #22