### PR TITLE
TEST/complete order - Ticket #19

### DIFF
--- a/bangazonapi/models/customer.py
+++ b/bangazonapi/models/customer.py
@@ -9,7 +9,7 @@ class Customer(models.Model):
     address = models.CharField(max_length=55)
 
     @property
-    def recommends(self):
+    def recommends(self):           
         return self.__recommends
 
     @recommends.setter

--- a/tests/order.py
+++ b/tests/order.py
@@ -29,6 +29,13 @@ class OrderTests(APITestCase):
         response = self.client.post(url, data, format='json')
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
+        # Create a payment type
+        url = "/paymenttypes"
+        data = {"merchant_name": "MYMEX", "account_number": 222222, "expiration_date": "2012-12-12"}
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+        response = self.client.post(url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
 
     def test_add_product_to_order(self):
         """
@@ -36,7 +43,7 @@ class OrderTests(APITestCase):
         """
         # Add product to order
         url = "/cart"
-        data = { "product_id": 1 }
+        data = { "id": 1 }
         self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
         response = self.client.post(url, data, format='json')
 
@@ -63,7 +70,7 @@ class OrderTests(APITestCase):
 
         # Remove product from cart
         url = "/cart/1"
-        data = { "product_id": 1 }
+        data = { "id": 1 }
         self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
         response = self.client.delete(url, data, format='json')
 
@@ -80,5 +87,27 @@ class OrderTests(APITestCase):
         self.assertEqual(len(json_response["lineitems"]), 0)
 
     # TODO: Complete order by adding payment type
+        
+    def test_add_payment_to_order(self):
+        # Add Product to create order 
+        self.test_add_product_to_order()
+
+        # Add payment to order
+        url = "/orders/1"
+        data = { "payment_type": 1 }
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+        response = self.client.put(url, data, format='json')
+
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+        # Get order to verify payment was added
+        url = "/orders/1"
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+        response = self.client.get(url, None, format='json')
+        json_response = json.loads(response.content)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(json_response["payment_type"]["id"], 1)
+
 
     # TODO: New line item is not added to closed order


### PR DESCRIPTION
The purpose of this pull request is to add integrated test to the API for completing an order by adding a payment type.

Ticket #19

## Changes

• first, the data for both test_add_product_to_order(self), and test_remove_product_from_order() was changed from "product_id" to "id" to correspond with a change in the API code

• in the OrderTests class, an payment type was created in the setup method, and then a new method to add payment type to an order was created. 

• This method first runs the add_product_to_order method to created an open order in the test file
• Then a payment type is added to this order and status code is confirmed.
• Lastly the order is retrieved with a GET request and checked to confirm that it now has a payment type, rather than NULL


**Test**
• Run the debugger in the API
• in the terminal, run the command python3 manage.py test tests -v 1
• The response should note that 7 tests were run, and "OK" to confirm that they were successful



