### PR TITLE
TEST/delete payment type - Ticket #17

### DIFF
--- a/tests/payments.py
+++ b/tests/payments.py
@@ -41,3 +41,45 @@ class PaymentTests(APITestCase):
         self.assertEqual(json_response["create_date"], str(datetime.date.today()))
 
     # TODO: Delete payment type
+        
+    def test_delete_payment_type(self):
+        
+        # confirm that user has no payment types
+        url = "/paymenttypes"
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+        response = self.client.get(url, None, format='json')
+        json_response = json.loads(response.content)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(json_response), 0)
+
+
+        # create a payment type for user
+        self.test_create_payment_type()
+
+        # confirm that payment type was added
+        url = "/paymenttypes"
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+        response = self.client.get(url, None, format='json')
+        json_response = json.loads(response.content)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(json_response), 1)
+
+        # delete the payment type
+        url ="/paymenttypes/1"
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+        response = self.client.delete(url, None, format='json')
+
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+        # get users payment types and confirm that there are none
+        url = "/paymenttypes"
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+        response = self.client.get(url, None, format='json')
+        json_response = json.loads(response.content)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(json_response), 0)
+
+        


### PR DESCRIPTION
The purpose of this pull request is to add an integrated test to the API that ensures that a payment method can successfully be deleted by its user

Ticket #seventeen

## Changes

• In the PaymentTests class, a new method was created that adds a payment type for the user, and deletes it.
• The users payment types are then requested to confirm that they now have none

**Test**
• Open the API and run the debugger
• In the terminal, run python3 manage.py test tetsts -v 1
• The response should be OK