### PR TITLE
Feature prodlist over xprice | API Side 

### DIFF
--- a/bangazon/settings.py
+++ b/bangazon/settings.py
@@ -108,7 +108,7 @@ DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
 
 
 # Password validation
-# https://docs.djangoproject.com/en/2.2/ref/settings/#auth-password-validators
+# https://docs.djangoproject.com/en/2.2/ref/settings/#databases
 
 AUTH_PASSWORD_VALIDATORS = [
     {

--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -267,6 +267,7 @@ class Products(ViewSet):
         order = self.request.query_params.get("order_by", None)
         direction = self.request.query_params.get("direction", None)
         number_sold = self.request.query_params.get("number_sold", None)
+        min_price = self.request.query_params.get("min_price")
 
         if order is not None:
             order_filter = order
@@ -291,6 +292,9 @@ class Products(ViewSet):
                 return False
 
             products = filter(sold_filter, products)
+
+        if min_price is not None:
+            products = products.filter(price__gte=min_price)
 
         serializer = ProductSerializer(
             products, many=True, context={"request": request}


### PR DESCRIPTION
When the client performs a GET request to the products resource, and specifies a minimum price as a query string parameter, the results should contain products whose price property value is equal to, or greater than, the value of the query string parameter.

## Changes

- updated `products = products.filter(price__gte=min_price)` to get minimum price greater than or equal to min_price

**Request**

GET `/products?min_price=150` Gets products with a minimum price of 150

```json
{
    "id": 1,
        "name": "Optima",
        "price": 1655.15,
        "number_sold": 0,
        "description": "2008 Kia",
        "quantity": 3,
        "created_date": "2019-05-21",
        "location": "Seoul",
        "image_path": "http://localhost:8000/media/products/vehicle.png",
        "average_rating": 0
}
```

**Response**

HTTP/1.1 201 OK

```json
[
    {
        "id": 1,
        "name": "Optima",
        "price": 1655.15,
        "number_sold": 0,
        "description": "2008 Kia",
        "quantity": 3,
        "created_date": "2019-05-21",
        "location": "Seoul",
        "image_path": "http://localhost:8000/media/products/vehicle.png",
        "average_rating": 0
    },
    {
        "id": 2,
        "name": "Golf",
        "price": 653.59,
        "number_sold": 0,
        "description": "1994 Volkswagen",
        "quantity": 4,
        "created_date": "2019-07-10",
        "location": "Paris",
        "image_path": "http://localhost:8000/media/products/vehicle.png",
        "average_rating": 0
    }
]
```

## Testing

In Postman:

- [ ] GET http://localhost:8000/products?min_price=150, hit SEND
- [ ] Response should return products at/over 150
- [ ] You can modify the min_price price to 1500 or 15 and you will see that products at/over that minimum price will be returned on Postman


## Related Issues

- Fixes # 25