### PR TITLE
added a line to set the property field of a new store in the create m…

### DIFF
--- a/bangazonapi/views/store.py
+++ b/bangazonapi/views/store.py
@@ -171,6 +171,7 @@ class Stores(ViewSet):
         new_store.description = request.data["description"]
         customer = Customer.objects.get(user=request.auth.user)
         new_store.seller = customer
+        new_store.products = Product.objects.filter(customer=new_store.seller)
         new_store.save()
 
         serializer = StoreSerializer(new_store, context={"request": request})


### PR DESCRIPTION
Fixed a bug in the create method of the Store view caused by adding a "products" property to the StoreSerializer. 
Added a line to set the products property of the new store in the create method.

## Changes
- Created a products list filtered by matching the customer id of the product to the seller id of the store, and set that products list equal to the products property of the new store

## Testing

Description of how to test code...

- [ ] Run your API debugger, start the development server, and make sure your database includes a store table
- [ ] Log in as a User who does not currently have a store.
- [ ] Navigate to the drop down menu on the top right of the page and click "Interested in selling?"
- [ ] Enter a name and description, then click Save
- [ ] You should have been navigated to the store's detail page without an error


## Related Issues

- Fixes # 1